### PR TITLE
Update name handling for Xaya

### DIFF
--- a/electrum_nmc/electrum/gui/qt/main_window.py
+++ b/electrum_nmc/electrum/gui/qt/main_window.py
@@ -3511,12 +3511,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.buy_names_new_name_lineedit.textChanged.connect(self.update_buy_names_preview)
         vbox.addWidget(self.buy_names_new_name_lineedit)
 
-        self.buy_names_format_explain_label = QLabel(_("<html><head/><body><p>Use <span style='font-weight:600;'>d/</span> prefix for domain names.  E.g. <span style='font-weight:600;'>d/mysite</span> will register <span style='font-weight:600;'>mysite.bit</span></p><p>See the <a href='https://github.com/namecoin/proposals/blob/master/ifa-0001.md'><span style='text-decoration:underline; color:#0000ff;'>Namecoin Domain Names specification</span></a> for reference.  Other prefixes can be used for miscellaneous purposes (not domain names).</p></body></html>"))
-        self.buy_names_format_explain_label.setTextFormat(Qt.RichText)
-        self.buy_names_format_explain_label.setWordWrap(True)
-        self.buy_names_format_explain_label.setOpenExternalLinks(True)
-        vbox.addWidget(self.buy_names_format_explain_label)
-
         self.buy_names_preview_label = QLabel(_("Name to register: "))
         vbox.addWidget(self.buy_names_preview_label)
 
@@ -3560,7 +3554,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
     def update_buy_names_preview(self):
         # TODO: handle non-ASCII encodings
-        identifier = self.buy_names_new_name_lineedit.text().encode('ascii')
+        identifier = self.buy_names_new_name_lineedit.text().encode('utf-8')
         identifier_formatted = format_name_identifier(identifier)
         self.buy_names_preview_label.setText(_("Name to register: ") + identifier_formatted)
 
@@ -3570,7 +3564,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
     def check_name_availability(self):
         # TODO: handle non-ASCII encodings
         identifier_ascii = self.buy_names_new_name_lineedit.text()
-        identifier = identifier_ascii.encode('ascii')
+        identifier = identifier_ascii.encode('utf-8')
 
         identifier_formatted = format_name_identifier(identifier)
 
@@ -3592,7 +3586,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
         if not name_valid:
             self.buy_names_available_widget.hide()
-            self.buy_names_already_exists_label.setText(_("That name is invalid (probably exceeded the 255-byte limit) and therefore cannot be registered."))
+            self.buy_names_already_exists_label.setText(_("That name is invalid and therefore cannot be registered."))
             self.buy_names_already_exists_widget.show()
         elif name_exists:
             self.buy_names_available_widget.hide()
@@ -3606,9 +3600,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
     def register_new_name(self):
         # TODO: handle non-ASCII encodings
         identifier_ascii = self.buy_names_new_name_lineedit.text()
-        identifier = identifier_ascii.encode('ascii')
+        identifier = identifier_ascii.encode('utf-8')
 
-        initial_value = b''
+        initial_value = b'{}'
 
         show_configure_name(identifier, initial_value, self, True)
 
@@ -3631,14 +3625,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.names_configure_button.setMinimumSize(150, 0)
         self.names_configure_button.setToolTip(_('Change the value of the selected name or transfer ownership'))
         self.names_configure_button.clicked.connect(l.configure_selected_item)
-        self.names_renew_button = QPushButton(_('Renew Name'))
-        self.names_renew_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.names_renew_button.setMinimumSize(150, 0)
-        self.names_renew_button.setToolTip(_('Renew the selected name with its current value (nothing will happen if the name was updated in the last 12 blocks)'))
-        self.names_renew_button.clicked.connect(l.renew_selected_items)
 
         self.names_actions_hbox.addWidget(self.names_configure_button)
-        self.names_actions_hbox.addWidget(self.names_renew_button)
 
         self.names_actions = QWidget()
         self.names_actions.setLayout(self.names_actions_hbox)

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -29,17 +29,11 @@ def split_name_script(decoded):
     if decoded is None:
         return {"name_op": None, "address_scriptPubKey": decoded}
 
-    # name_new TxOuts look like:
-    # NAME_NEW (hash) 2DROP (Bitcoin TxOut)
-    match = [ OP_NAME_NEW, OPPushDataGeneric, opcodes.OP_2DROP ]
+    # name_register TxOuts look like:
+    # NAME_REGISTER (name) (value) 2DROP DROP (Bitcoin TxOut)
+    match = [ OP_NAME_REGISTER, OPPushDataGeneric, OPPushDataGeneric, opcodes.OP_2DROP, opcodes.OP_DROP ]
     if match_decoded(decoded[:len(match)], match):
-        return {"name_op": {"op": OP_NAME_NEW, "hash": decoded[1][1]}, "address_scriptPubKey": decoded[len(match):]}
-
-    # name_firstupdate TxOuts look like:
-    # NAME_FIRSTUPDATE (name) (rand) (value) 2DROP 2DROP (Bitcoin TxOut)
-    match = [ OP_NAME_FIRSTUPDATE, OPPushDataGeneric, OPPushDataGeneric, OPPushDataGeneric, opcodes.OP_2DROP, opcodes.OP_2DROP ]
-    if match_decoded(decoded[:len(match)], match):
-        return {"name_op": {"op": OP_NAME_FIRSTUPDATE, "name": decoded[1][1], "rand": decoded[2][1], "value": decoded[3][1]}, "address_scriptPubKey": decoded[len(match):]}
+        return {"name_op": {"op": OP_NAME_REGISTER, "name": decoded[1][1], "value": decoded[2][1]}, "address_scriptPubKey": decoded[len(match):]}
 
     # name_update TxOuts look like:
     # NAME_UPDATE (name) (value) 2DROP DROP (Bitcoin TxOut)
@@ -61,22 +55,16 @@ def get_name_op_from_output_script(_bytes):
 def name_op_to_script(name_op):
     if name_op is None:
         script = ''
-    elif name_op["op"] == OP_NAME_NEW:
-        validate_new_length(name_op)
-        script = '51'                                 # OP_NAME_NEW
-        script += push_script(bh2u(name_op["hash"]))
-        script += '6d'                                # OP_2DROP
-    elif name_op["op"] == OP_NAME_FIRSTUPDATE:
-        validate_firstupdate_length(name_op)
-        script = '52'                                 # OP_NAME_FIRSTUPDATE
+    elif name_op["op"] == OP_NAME_REGISTER:
+        validate_update_length(name_op)
+        script = '51'                                 # OP_NAME_REGISTER
         script += push_script(bh2u(name_op["name"]))
-        script += push_script(bh2u(name_op["rand"]))
         script += push_script(bh2u(name_op["value"]))
         script += '6d'                                # OP_2DROP
-        script += '6d'                                # OP_2DROP
+        script += '75'                                # OP_DROP
     elif name_op["op"] == OP_NAME_UPDATE:
         validate_update_length(name_op)
-        script = '53'                                 # OP_NAME_UPDATE
+        script = '52'                                 # OP_NAME_UPDATE
         script += push_script(bh2u(name_op["name"]))
         script += push_script(bh2u(name_op["value"]))
         script += '6d'                                # OP_2DROP
@@ -85,13 +73,6 @@ def name_op_to_script(name_op):
         raise BitcoinException('unknown name op: {}'.format(name_op))
     return script
 
-def validate_new_length(name_op):
-    validate_hash_length(name_op["hash"])
-
-def validate_firstupdate_length(name_op):
-    validate_rand_length(name_op["rand"])
-    validate_anyupdate_length(name_op)
-
 def validate_update_length(name_op):
     validate_anyupdate_length(name_op)
 
@@ -99,44 +80,36 @@ def validate_anyupdate_length(name_op):
     validate_identifier_length(name_op["name"])
     validate_value_length(name_op["value"])
 
-def validate_hash_length(commitment):
-    hash_length_requirement = 20
-
-    hash_length = len(commitment)
-    if hash_length != hash_length_requirement:
-        raise BitcoinException('hash length {} is not equal to requirement of {}'.format(hash_length, hash_length_requirement))
-
-def validate_rand_length(rand):
-    rand_length_requirement = 20
-
-    rand_length = len(rand)
-    if rand_length != rand_length_requirement:
-        raise BitcoinException('rand length {} is not equal to requirement of {}'.format(rand_length, rand_length_requirement))
-
 def validate_identifier_length(identifier):
-    identifier_length_limit = 255
+    identifier_length_limit = 256
 
     identifier_length = len(identifier)
     if identifier_length > identifier_length_limit:
         raise BitcoinException('identifier length {} exceeds limit of {}'.format(identifier_length, identifier_length_limit))
 
+    # TODO: Xaya has more validation rules, which we should at some point
+    # implement here as well.
+
 def validate_value_length(value):
-    value_length_limit = 520
+    # Special case:  This is also called when we build the "fake name script"
+    # that ElectrumX indexes on.  In this case, the value is empty.  That is
+    # not valid for Xaya, but we need to accept it here.
+    if len(value) == 0:
+        return
+
+    value_length_limit = 2048
 
     value_length = len(value)
     if value_length > value_length_limit:
         raise BitcoinException('value length {} exceeds limit of {}'.format(value_length, value_length_limit))
 
-def build_name_new(identifier, rand = None):
-    validate_identifier_length(identifier)
-
-    if rand is None:
-        rand = os.urandom(20)
-
-    to_hash = rand + identifier
-    commitment = hash_160(to_hash)
-
-    return {"op": OP_NAME_NEW, "hash": commitment}, rand
+    import json
+    try:
+        parsed = json.loads(value)
+        if not isinstance (parsed, dict):
+            raise BitcoinException(f"Value is not a JSON object: {value}")
+    except json.decoder.JSONDecodeError:
+        raise BitcoinException(f"Value is invalid JSON: {value}")
 
 def name_identifier_to_scripthash(identifier_bytes):
     name_op = {"op": OP_NAME_UPDATE, "name": identifier_bytes, "value": bytes([])}
@@ -148,64 +121,27 @@ def name_identifier_to_scripthash(identifier_bytes):
 
 def format_name_identifier(identifier_bytes):
     try:
-        identifier = identifier_bytes.decode("ascii")
+        identifier = identifier_bytes.decode("utf-8")
     except UnicodeDecodeError:
         return format_name_identifier_unknown_hex(identifier_bytes)
 
-    is_domain_namespace = identifier.startswith("d/")
-    if is_domain_namespace:
-        return format_name_identifier_domain(identifier)
+    if identifier.startswith("p/"):
+        return format_name_identifier_player(identifier)
 
-    is_identity_namespace = identifier.startswith("id/")
-    if is_identity_namespace:
-        return format_name_identifier_identity(identifier)
+    if identifier.startswith("g/"):
+        return format_name_identifier_game(identifier)
 
     return format_name_identifier_unknown(identifier)
 
 
-def format_name_identifier_domain(identifier):
-    label = identifier[len("d/"):]
-
-    if len(label) < 1:
-        return format_name_identifier_unknown(identifier)
-
-    # Source: https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys
-    if len(label) > 63:
-        return format_name_identifier_unknown(identifier)
-
-    # Source: https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys
-    label_regex = r"^(xn--)?[a-z0-9]+(-[a-z0-9]+)*$"
-    label_match = re.match(label_regex, label)
-    if label_match is None:
-        return format_name_identifier_unknown(identifier)
-
-    # Reject digits-only labels
-    number_regex = r"^[0-9]+$"
-    number_match = re.match(number_regex, label)
-    if number_match is not None:
-        return format_name_identifier_unknown(identifier)
-
-    return "Domain " + label + ".bit"
+def format_name_identifier_player(identifier):
+    label = identifier[len("p/"):]
+    return f"Player: {label}"
 
 
-def format_name_identifier_identity(identifier):
-    label = identifier[len("id/"):]
-
-    if len(label) < 1:
-        return format_name_identifier_unknown(identifier)
-
-    # Max id/ identifier length is 255 chars according to wiki spec.  But we
-    # don't need to check for this, because that's also the max length of an
-    # identifier under the Namecoin consensus rules.
-
-    # Same as d/ regex but without IDN prefix.
-    # TODO: this doesn't exactly match the https://wiki.namecoin.org spec.
-    label_regex = r"^[a-z0-9]+(-[a-z0-9]+)*$"
-    label_match = re.match(label_regex, label)
-    if label_match is None:
-        return format_name_identifier_unknown(identifier)
-
-    return "Identity " + label
+def format_name_identifier_game(identifier):
+    label = identifier[len("g/"):]
+    return f"Game: {label}"
 
 def format_name_identifier_unknown(identifier):
     # Check for non-printable characters, and print ASCII if none are found.
@@ -228,7 +164,7 @@ def format_name_value(identifier_bytes):
     if not identifier.isprintable():
         return format_name_value_hex(identifier_bytes)
 
-    return "ASCII " + identifier
+    return "JSON " + identifier
 
 
 def format_name_value_hex(identifier_bytes):
@@ -238,19 +174,13 @@ def format_name_value_hex(identifier_bytes):
 def format_name_op(name_op):
     if name_op is None:
         return ''
-    if "hash" in name_op:
-        formatted_hash = "Commitment = " + bh2u(name_op["hash"])
-    if "rand" in name_op:
-        formatted_rand = "Salt = " + bh2u(name_op["rand"])
     if "name" in name_op:
         formatted_name = "Name = " + format_name_identifier(name_op["name"])
     if "value" in name_op:
         formatted_value = "Data = " + format_name_value(name_op["value"])
 
-    if name_op["op"] == OP_NAME_NEW:
-        return "\tPre-Registration\n\t\t" + formatted_hash
-    if name_op["op"] == OP_NAME_FIRSTUPDATE:
-        return "\tRegistration\n\t\t" + formatted_name + "\n\t\t" + formatted_rand + "\n\t\t" + formatted_value
+    if name_op["op"] == OP_NAME_REGISTER:
+        return "\tRegistration\n\t\t" + formatted_name + "\n\t\t" + formatted_value
     if name_op["op"] == OP_NAME_UPDATE:
         return "\tUpdate\n\t\t" + formatted_name + "\n\t\t" + formatted_value
 
@@ -263,77 +193,14 @@ def get_default_name_tx_label(wallet, tx):
             name_input_is_mine, name_output_is_mine, name_value_is_unchanged = get_wallet_name_delta(wallet, tx)
             if not name_input_is_mine and not name_output_is_mine:
                 return None
+            if name_op["op"] == OP_NAME_REGISTER:
+                return "Registration: " + format_name_identifier(name_op["name"])
             if name_input_is_mine and not name_output_is_mine:
                 return "Transfer (Outgoing): " + format_name_identifier(name_op["name"])
             if not name_input_is_mine and name_output_is_mine:
-                # A name_new transaction isn't expected to have a name input,
-                # so we don't consider it a transfer.
-                if name_op["op"] != OP_NAME_NEW:
-                    return "Transfer (Incoming): " + format_name_identifier(name_op["name"])
-            if name_op["op"] == OP_NAME_NEW:
-                # Get the address where the NAME_NEW was sent to
-                addr = o.address
-                # Look for other transactions for this address, which might
-                # include the NAME_FIRSTUPDATE
-                addr_history = wallet.get_address_history(addr)
-                for addr_txid, addr_height in addr_history:
-                    # Examine a candidate tx that might be the NAME_FIRSTUPDATE
-                    addr_tx = wallet.db.transactions.get(addr_txid)
-                    # Look at all the candidate's inputs to make sure it's
-                    # actually spending the NAME_NEW
-                    for addr_tx_input in addr_tx.inputs():
-                        if addr_tx_input['prevout_hash'] == tx.txid():
-                            if addr_tx_input['prevout_n'] == idx:
-                                # We've confirmed that it spends the NAME_NEW.
-                                # Look at the outputs to find the
-                                # NAME_FIRSTUPDATE.
-                                for addr_tx_output in addr_tx.outputs():
-                                    if addr_tx_output.name_op is not None:
-                                        # We've found a name output; now we
-                                        # check for an identifier.
-                                        if 'name' in addr_tx_output.name_op:
-                                            return "Pre-Registration: " + format_name_identifier(addr_tx_output.name_op['name'])
-
-                # Look for queued transactions that spend the NAME_NEW
-                addr_tx_output = get_queued_firstupdate_from_new(wallet, tx.txid(), idx)
-                if addr_tx_output is not None:
-                    return "Pre-Registration: " + format_name_identifier(addr_tx_output.name_op['name'])
-
-                # A name_new transaction doesn't have a visible 'name' field,
-                # so there's nothing to format if we can't find the name
-                # elsewhere in the wallet.
-                return "Pre-Registration"
-            if name_op["op"] == OP_NAME_FIRSTUPDATE:
-                return "Registration: " + format_name_identifier(name_op["name"])
+                return "Transfer (Incoming): " + format_name_identifier(name_op["name"])
             if name_op["op"] == OP_NAME_UPDATE:
-                if name_value_is_unchanged:
-                    return "Renew: " + format_name_identifier(name_op["name"])
-                else:
-                    return "Update: " + format_name_identifier(name_op["name"])
-    return None
-
-
-def get_queued_firstupdate_from_new(wallet, txid, idx):
-    # Look for queued transactions that spend the NAME_NEW
-    for addr_txid in wallet.db.queued_transactions:
-        addr_tx_queue_item = wallet.db.queued_transactions[addr_txid]
-        # Check whether the queued transaction is contingent on the NAME_NEW transaction
-        if addr_tx_queue_item['sendWhen']['txid'] == txid:
-            addr_tx = Transaction(addr_tx_queue_item['tx'])
-            # Look at all the candidate's inputs to make sure it's
-            # actually spending the NAME_NEW
-            for addr_tx_input in addr_tx.inputs():
-                if addr_tx_input['prevout_hash'] == txid:
-                    if addr_tx_input['prevout_n'] == idx:
-                        # We've confirmed that it spends the NAME_NEW.
-                        # Look at the outputs to find the
-                        # NAME_FIRSTUPDATE.
-                        for addr_tx_output in addr_tx.outputs():
-                            if addr_tx_output.name_op is not None:
-                                # We've found a name output; now we
-                                # check for an identifier.
-                                if 'name' in addr_tx_output.name_op:
-                                    return addr_tx_output
+                return "Update: " + format_name_identifier(name_op["name"])
     return None
 
 
@@ -375,11 +242,9 @@ def get_wallet_name_count(wallet, network):
         if name_op is None:
             continue
         height = x.get('height')
-        chain_height = network.blockchain().height()
-        expires_in = name_expires_in(height, chain_height)
-        if expires_in is None:
+        if height <= 0:
             # Transaction isn't mined yet
-            if name_op['op'] in [OP_NAME_NEW, OP_NAME_FIRSTUPDATE]:
+            if name_op['op'] == OP_NAME_REGISTER:
                 # Registration is pending
                 pending_count += 1
                 continue
@@ -389,9 +254,6 @@ def get_wallet_name_count(wallet, network):
                 # or outgoing transfer.
                 confirmed_count += 1
                 continue
-        if expires_in <= 0:
-            # Expired
-            continue
         if 'name' in name_op:
             # name_anyupdate is mined (not expired)
             confirmed_count += 1
@@ -401,25 +263,6 @@ def get_wallet_name_count(wallet, network):
             pending_count += 1
             continue
     return confirmed_count, pending_count
-
-
-def name_expires_in(name_height, chain_height):
-    if name_height <= 0:
-        return None
-
-    return name_height - chain_height + 36000
-
-
-def name_expiration_datetime_estimate(name_height, chain_height, chain_unixtime):
-    expiration_blocks = name_expires_in(name_height, chain_height)
-
-    if expiration_blocks is None:
-        return None, None
-
-    block_timedelta = timedelta(minutes=10)
-    expiration_timedelta = expiration_blocks * block_timedelta
-    chain_datetime = datetime.fromtimestamp(chain_unixtime)
-    return expiration_blocks, chain_datetime + expiration_timedelta
 
 
 import binascii
@@ -432,7 +275,5 @@ from .crypto import hash_160
 from .transaction import MalformedBitcoinScript, match_decoded, opcodes, OPPushDataGeneric, script_GetOp, Transaction
 from .util import bh2u, BitcoinException
 
-OP_NAME_NEW = opcodes.OP_1
-OP_NAME_FIRSTUPDATE = opcodes.OP_2
-OP_NAME_UPDATE = opcodes.OP_3
-
+OP_NAME_REGISTER = opcodes.OP_1
+OP_NAME_UPDATE = opcodes.OP_2

--- a/electrum_nmc/electrum/transaction.py
+++ b/electrum_nmc/electrum/transaction.py
@@ -51,8 +51,6 @@ _logger = get_logger(__name__)
 NO_SIGNATURE = 'ff'
 PARTIAL_TXN_HEADER_MAGIC = b'EPTF\xff'
 
-NAMECOIN_VERSION = 0x7100
-
 
 class SerializationError(Exception):
     """ Thrown when there's a problem deserializing or serializing """
@@ -780,9 +778,6 @@ class Transaction:
         self = klass(None)
         self._inputs = inputs
         self._outputs = outputs
-        for o in outputs:
-            if o.name_op is not None:
-                self.version = NAMECOIN_VERSION
         self.locktime = locktime
         if version is not None:
             self.version = version
@@ -1151,7 +1146,7 @@ class Transaction:
         for o in self.outputs():
             if o.name_op is None:
                 continue
-            if o.name_op['op'] == OP_NAME_NEW:
+            if o.name_op['op'] == OP_NAME_REGISTER:
                 newly_locked_amount += COIN // 100
         return newly_locked_amount + sum(o.value for o in self.outputs())
 
@@ -1317,5 +1312,5 @@ def tx_from_str(txt: str) -> str:
     return tx_dict["hex"]
 
 
-from .names import get_name_op_from_output_script, name_op_to_script, OP_NAME_NEW, split_name_script
+from .names import get_name_op_from_output_script, name_op_to_script, OP_NAME_REGISTER, split_name_script
 

--- a/electrum_nmc/electrum/wallet.py
+++ b/electrum_nmc/electrum/wallet.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
     from .simple_config import SimpleConfig
 
 
-from .names import (get_default_name_tx_label, OP_NAME_NEW, OP_NAME_FIRSTUPDATE,
+from .names import (get_default_name_tx_label, OP_NAME_REGISTER,
                     OP_NAME_UPDATE)
 
 _logger = get_logger(__name__)
@@ -700,7 +700,7 @@ class Abstract_Wallet(AddressSynchronizer):
             # identifier
             if name_op is not None:
                 # We'll be adding a name operation to the base tx.
-                if name_op["op"] in [OP_NAME_NEW, OP_NAME_FIRSTUPDATE]:
+                if name_op["op"] == OP_NAME_REGISTER:
                     # We'll be adding a name registration operation to the base tx.
                     if any([o.name_op is not None for o in tx.outputs()]):
                         # The base tx already has a name operation.  Don't use
@@ -708,7 +708,7 @@ class Abstract_Wallet(AddressSynchronizer):
                         continue
                 else:
                     # We'll be adding a name_update operation to the base tx.
-                    if any([o.name_op is not None and o.name_op["op"] in [OP_NAME_NEW, OP_NAME_FIRSTUPDATE] for o in tx.outputs()]):
+                    if any([o.name_op is not None and o.name_op["op"] == OP_NAME_REGISTER for o in tx.outputs()]):
                         # The base tx already has a name registration
                         # operation.  Don't use it.
                         continue


### PR DESCRIPTION
This updates the name handling of Electrum-NMC to the needs of Xaya.  The main differences are that names do not expire and that registration is done with a single transaction, rather than with the "name_new/name_firstupdate" two-stage process of Namecoin.