### PR TITLE
Fixed dir in README: electrum_nmc to electrum_chi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,8 @@ Compile the Qt UI::
 
 Copy over the www root::
 
-    rm -rf electrum_nmc/electrum/www
-    cp -a electrum/www electrum_nmc/electrum/www
+    rm -rf electrum_chi/electrum/www
+    cp -a electrum/www electrum_chi/electrum/www
 
 Create translations (optional)::
 


### PR DESCRIPTION
Changed directory name from electrum_nmc (non-existent dir) to electrum_chi.
Probably remained from Namecoin.